### PR TITLE
01_wait_forever: support riscv32/riscv64

### DIFF
--- a/01_wait_forever/Cargo.toml
+++ b/01_wait_forever/Cargo.toml
@@ -10,5 +10,6 @@ default = []
 bsp_rpi3 = []
 bsp_rpi4 = []
 bsp_hifive1 = []
+bsp_hifive_unleashed = []
 
 [dependencies]

--- a/01_wait_forever/Cargo.toml
+++ b/01_wait_forever/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2018"
 default = []
 bsp_rpi3 = []
 bsp_rpi4 = []
+bsp_hifive1 = []
 
 [dependencies]

--- a/01_wait_forever/Makefile
+++ b/01_wait_forever/Makefile
@@ -37,6 +37,17 @@ else ifeq ($(BSP),hifive1)
     CPU_ARCH          = riscv32
     # Use its own image until rustembedded/osdev-utils supports riscv32.
     DOCKER_IMAGE      = imsuten/osdev-utils
+else ifeq ($(BSP),hifive_unleashed)
+    TARGET            = riscv64gc-unknown-none-elf
+    KERNEL_BIN        = kernel8.img
+    QEMU_BINARY       = qemu-system-riscv64
+    QEMU_MACHINE_TYPE = sifive_u
+    QEMU_RELEASE_ARGS = -d in_asm -display none -bios none
+    LINKER_FILE       = src/bsp/hifive_unleashed/link.ld
+    RUSTC_MISC_ARGS   = -C target-cpu=generic-rv64
+    CPU_ARCH          = riscv64
+    # Use its own image until rustembedded/osdev-utils supports riscv32.
+    DOCKER_IMAGE      = imsuten/osdev-utils
 endif
 
 # Export for build.rs
@@ -85,6 +96,9 @@ else ifeq ($(BSP),rpi4)
 qemu:
 	@echo "This board is not yet supported for QEMU."
 else ifeq ($(BSP),hifive1)
+qemu: $(KERNEL_ELF)
+	@$(DOCKER_QEMU) $(EXEC_QEMU) $(QEMU_RELEASE_ARGS) -kernel $(KERNEL_ELF)
+else ifeq ($(BSP),hifive_unleashed)
 qemu: $(KERNEL_ELF)
 	@$(DOCKER_QEMU) $(EXEC_QEMU) $(QEMU_RELEASE_ARGS) -kernel $(KERNEL_ELF)
 endif

--- a/01_wait_forever/Makefile
+++ b/01_wait_forever/Makefile
@@ -14,8 +14,8 @@ ifeq ($(BSP),rpi3)
     QEMU_RELEASE_ARGS = -d in_asm -display none
     LINKER_FILE       = src/bsp/raspberrypi/link.ld
     RUSTC_MISC_ARGS   = -C target-cpu=cortex-a53
-	CPU_ARCH          = aarch64
-	DOCKER_IMAGE      = rustembedded/osdev-utils
+    CPU_ARCH          = aarch64
+    DOCKER_IMAGE      = rustembedded/osdev-utils
 else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
@@ -24,8 +24,8 @@ else ifeq ($(BSP),rpi4)
     QEMU_RELEASE_ARGS = -d in_asm -display none
     LINKER_FILE       = src/bsp/raspberrypi/link.ld
     RUSTC_MISC_ARGS   = -C target-cpu=cortex-a72
-	CPU_ARCH          = aarch64
-	DOCKER_IMAGE      = rustembedded/osdev-utils
+    CPU_ARCH          = aarch64
+    DOCKER_IMAGE      = rustembedded/osdev-utils
 else ifeq ($(BSP),hifive1)
     TARGET            = riscv32imac-unknown-none-elf
     KERNEL_BIN        = kernel8.img
@@ -34,9 +34,9 @@ else ifeq ($(BSP),hifive1)
     QEMU_RELEASE_ARGS = -d in_asm -display none -bios none
     LINKER_FILE       = src/bsp/hifive1/link.ld
     RUSTC_MISC_ARGS   = -C target-cpu=generic-rv32
-	CPU_ARCH          = riscv32
-	# Use its own image until rustembedded/osdev-utils supports riscv32.
-	DOCKER_IMAGE      = imsuten/osdev-utils
+    CPU_ARCH          = riscv32
+    # Use its own image until rustembedded/osdev-utils supports riscv32.
+    DOCKER_IMAGE      = imsuten/osdev-utils
 endif
 
 # Export for build.rs

--- a/01_wait_forever/Makefile
+++ b/01_wait_forever/Makefile
@@ -14,6 +14,8 @@ ifeq ($(BSP),rpi3)
     QEMU_RELEASE_ARGS = -d in_asm -display none
     LINKER_FILE       = src/bsp/raspberrypi/link.ld
     RUSTC_MISC_ARGS   = -C target-cpu=cortex-a53
+	CPU_ARCH          = aarch64
+	DOCKER_IMAGE      = rustembedded/osdev-utils
 else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
@@ -22,6 +24,19 @@ else ifeq ($(BSP),rpi4)
     QEMU_RELEASE_ARGS = -d in_asm -display none
     LINKER_FILE       = src/bsp/raspberrypi/link.ld
     RUSTC_MISC_ARGS   = -C target-cpu=cortex-a72
+	CPU_ARCH          = aarch64
+	DOCKER_IMAGE      = rustembedded/osdev-utils
+else ifeq ($(BSP),hifive1)
+    TARGET            = riscv32imac-unknown-none-elf
+    KERNEL_BIN        = kernel8.img
+    QEMU_BINARY       = qemu-system-riscv32
+    QEMU_MACHINE_TYPE = sifive_e
+    QEMU_RELEASE_ARGS = -d in_asm -display none -bios none
+    LINKER_FILE       = src/bsp/hifive1/link.ld
+    RUSTC_MISC_ARGS   = -C target-cpu=generic-rv32
+	CPU_ARCH          = riscv32
+	# Use its own image until rustembedded/osdev-utils supports riscv32.
+	DOCKER_IMAGE      = imsuten/osdev-utils
 endif
 
 # Export for build.rs
@@ -44,8 +59,7 @@ OBJCOPY_CMD = rust-objcopy \
 
 KERNEL_ELF = target/$(TARGET)/release/kernel
 
-DOCKER_IMAGE         = rustembedded/osdev-utils
-DOCKER_CMD           = docker run -it --rm -v $(shell pwd):/work/tutorial -w /work/tutorial
+DOCKER_CMD = docker run -it --rm -v $(shell pwd):/work/tutorial -w /work/tutorial
 
 DOCKER_QEMU = $(DOCKER_CMD) $(DOCKER_IMAGE)
 
@@ -64,12 +78,15 @@ $(KERNEL_BIN): $(KERNEL_ELF)
 doc:
 	$(DOC_CMD) --document-private-items --open
 
-ifeq ($(QEMU_MACHINE_TYPE),)
-qemu:
-	@echo "This board is not yet supported for QEMU."
-else
+ifeq ($(BSP),rpi3)
 qemu: $(KERNEL_BIN)
 	@$(DOCKER_QEMU) $(EXEC_QEMU) $(QEMU_RELEASE_ARGS) -kernel $(KERNEL_BIN)
+else ifeq ($(BSP),rpi4)
+qemu:
+	@echo "This board is not yet supported for QEMU."
+else ifeq ($(BSP),hifive1)
+qemu: $(KERNEL_ELF)
+	@$(DOCKER_QEMU) $(EXEC_QEMU) $(QEMU_RELEASE_ARGS) -kernel $(KERNEL_ELF)
 endif
 
 clippy:
@@ -82,7 +99,7 @@ readelf: $(KERNEL_ELF)
 	readelf -a $(KERNEL_ELF)
 
 objdump: $(KERNEL_ELF)
-	rust-objdump --arch-name aarch64 --disassemble --demangle --no-show-raw-insn \
+	rust-objdump --arch-name $(CPU_ARCH) --disassemble --demangle --no-show-raw-insn \
 	    --print-imm-hex $(KERNEL_ELF)
 
 nm: $(KERNEL_ELF)

--- a/01_wait_forever/README.md
+++ b/01_wait_forever/README.md
@@ -19,12 +19,11 @@ executing the kernel code.
 ## Code to look at
 
 - Custom `link.ld` linker script.
-    - Load address at `0x80_000`
+    - Load address at `0x80_000` for RPi and `0x20400000` for HiFive1.
     - Only `.text` section.
 - `main.rs`: Important [inner attributes]:
     - `#![no_std]`, `#![no_main]`
-- `cpu.S`: Assembly `_start()` function that executes `wfe` (Wait For Event), halting all cores that
-  are executing `_start()`.
+- `cpu.S`: Assembly `_start()` function that executes `wfe` (Wait For Event) for RPi and `wfi` (Wait For Interrupt) for HiFive1, halting all cores that are executing `_start()`.
 - We (have to) define a `#[panic_handler]` function.
     - Just waits infinitely for a cpu event.
 

--- a/01_wait_forever/src/_arch/riscv32/cpu.S
+++ b/01_wait_forever/src/_arch/riscv32/cpu.S
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+
+.section ".text._start"
+
+.global _start
+
+_start:
+1:  wfi         // Wait for interrupt
+    j       1b  // In case an event happened, jump back to 1

--- a/01_wait_forever/src/_arch/riscv32/cpu.rs
+++ b/01_wait_forever/src/_arch/riscv32/cpu.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+
+//! Architectural processor code.
+
+// Assembly counterpart to this file.
+global_asm!(include_str!("cpu.S"));
+
+//--------------------------------------------------------------------------------------------------
+// Public Code
+//--------------------------------------------------------------------------------------------------
+
+/// Pause execution on the core.
+#[inline(always)]
+pub fn wait_forever() -> ! {
+    unsafe {
+        loop {
+            llvm_asm!("wfi"
+                    :             // outputs
+                    :             // inputs
+                    :             // clobbers
+                    : "volatile") // options
+        }
+    }
+}

--- a/01_wait_forever/src/_arch/riscv64/cpu.S
+++ b/01_wait_forever/src/_arch/riscv64/cpu.S
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+
+.section ".text._start"
+
+.global _start
+
+_start:
+1:  wfi         // Wait for interrupt
+    j       1b  // In case an event happened, jump back to 1

--- a/01_wait_forever/src/_arch/riscv64/cpu.rs
+++ b/01_wait_forever/src/_arch/riscv64/cpu.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+
+//! Architectural processor code.
+
+// Assembly counterpart to this file.
+global_asm!(include_str!("cpu.S"));
+
+//--------------------------------------------------------------------------------------------------
+// Public Code
+//--------------------------------------------------------------------------------------------------
+
+/// Pause execution on the core.
+#[inline(always)]
+pub fn wait_forever() -> ! {
+    unsafe {
+        loop {
+            llvm_asm!("wfi"
+                    :             // outputs
+                    :             // inputs
+                    :             // clobbers
+                    : "volatile") // options
+        }
+    }
+}

--- a/01_wait_forever/src/bsp.rs
+++ b/01_wait_forever/src/bsp.rs
@@ -9,3 +9,9 @@ mod raspberrypi;
 
 #[cfg(any(feature = "bsp_rpi3", feature = "bsp_rpi4"))]
 pub use raspberrypi::*;
+
+#[cfg(feature = "bsp_hifive1")]
+mod hifive1;
+
+#[cfg(feature = "bsp_hifive1")]
+pub use hifive1::*;

--- a/01_wait_forever/src/bsp.rs
+++ b/01_wait_forever/src/bsp.rs
@@ -15,3 +15,9 @@ mod hifive1;
 
 #[cfg(feature = "bsp_hifive1")]
 pub use hifive1::*;
+
+#[cfg(feature = "bsp_hifive_unleashed")]
+mod hifive_unleashed;
+
+#[cfg(feature = "bsp_hifive_unleashed")]
+pub use hifive_unleashed::*;

--- a/01_wait_forever/src/bsp/hifive1.rs
+++ b/01_wait_forever/src/bsp/hifive1.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+
+//! Top-level BSP file for the HiFive1.
+
+// Coming soon.

--- a/01_wait_forever/src/bsp/hifive1/link.ld
+++ b/01_wait_forever/src/bsp/hifive1/link.ld
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+ */
+
+OUTPUT_ARCH("riscv")
+
+ENTRY(_start)
+
+SECTIONS
+{
+    /* Set current address to the value from which the RPi starts execution */
+    . = 0x20400000;
+
+    .text :
+    {
+        *(.text._start) *(.text*)
+    }
+
+    /DISCARD/ : { *(.comment*) }
+}

--- a/01_wait_forever/src/bsp/hifive1/link.ld
+++ b/01_wait_forever/src/bsp/hifive1/link.ld
@@ -9,7 +9,7 @@ ENTRY(_start)
 
 SECTIONS
 {
-    /* Set current address to the value from which the RPi starts execution */
+    /* Set current address to the value from which the HiFive1 starts execution */
     . = 0x20400000;
 
     .text :

--- a/01_wait_forever/src/bsp/hifive_unleashed.rs
+++ b/01_wait_forever/src/bsp/hifive_unleashed.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+
+//! Top-level BSP file for the HiFive1.
+
+// Coming soon.

--- a/01_wait_forever/src/bsp/hifive_unleashed/link.ld
+++ b/01_wait_forever/src/bsp/hifive_unleashed/link.ld
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0
+ *
+ * Copyright (c) 2020 Ken Kawamoto <kentaro.kawamoto@gmail.com>
+ */
+
+OUTPUT_ARCH("riscv")
+
+ENTRY(_start)
+
+SECTIONS
+{
+    /* Set current address to the value from which the HiFive1 starts execution */
+    . = 0x80000000;
+
+    .text :
+    {
+        *(.text._start) *(.text*)
+    }
+
+    /DISCARD/ : { *(.comment*) }
+}

--- a/01_wait_forever/src/cpu.rs
+++ b/01_wait_forever/src/cpu.rs
@@ -12,4 +12,8 @@ mod arch_cpu;
 #[path = "_arch/riscv32/cpu.rs"]
 mod arch_cpu;
 
+#[cfg(target_arch = "riscv64")]
+#[path = "_arch/riscv64/cpu.rs"]
+mod arch_cpu;
+
 pub use arch_cpu::*;

--- a/01_wait_forever/src/cpu.rs
+++ b/01_wait_forever/src/cpu.rs
@@ -7,4 +7,10 @@
 #[cfg(target_arch = "aarch64")]
 #[path = "_arch/aarch64/cpu.rs"]
 mod arch_cpu;
+
+#[cfg(target_arch = "riscv32")]
+#[path = "_arch/riscv32/cpu.rs"]
+mod arch_cpu;
+
+
 pub use arch_cpu::*;

--- a/01_wait_forever/src/cpu.rs
+++ b/01_wait_forever/src/cpu.rs
@@ -12,5 +12,4 @@ mod arch_cpu;
 #[path = "_arch/riscv32/cpu.rs"]
 mod arch_cpu;
 
-
 pub use arch_cpu::*;

--- a/docker/rustembedded-osdev-utils/Dockerfile
+++ b/docker/rustembedded-osdev-utils/Dockerfile
@@ -46,7 +46,9 @@ RUN set -ex;                                        \
     git clone git://git.qemu.org/qemu.git;                     \
     cd qemu;                                                   \
     git checkout tags/v5.0.0;                                  \
-    ./configure --target-list=aarch64-softmmu --enable-modules \
+    ./configure                                                \
+        --target-list=aarch64-softmmu,riscv32-softmmu          \
+        --enable-modules                                       \
         --enable-tcg-interpreter --enable-debug-tcg            \
         --python=/usr/bin/python3;                             \
     make -j8;                                                  \

--- a/docker/rustembedded-osdev-utils/Makefile
+++ b/docker/rustembedded-osdev-utils/Makefile
@@ -9,3 +9,9 @@ docker_build:
 	docker build -t rustembedded/osdev-utils \
 	--build-arg VCS_REF=`git rev-parse --short HEAD` .
 	rm Gemfile
+
+docker_build_riscv:
+	cp ../../Gemfile .
+	docker build -t imsuten/osdev-utils \
+	--build-arg VCS_REF=`git rev-parse --short HEAD` .
+	rm Gemfile


### PR DESCRIPTION
Add support for riscv32/[HiFive1](https://www.sifive.com/boards/hifive1) and riscv64/[HiFive Unleashed](https://www.sifive.com/boards/hifive-unleashed) in section `01_wait_forever`.

When I was testing riscv32 with QEMU, I encountered a problem, probably the same issue as [this](https://github.com/riscv/riscv-qemu/issues/137).
Although I do not own "HiFive Unleashed" board, adding riscv64 helps me develop as the issue does not happen with `sifive_u` machine on QEMU.


```
❯ make qemu BSP=hifive1
RUSTFLAGS="-C link-arg=-Tsrc/bsp/hifive1/link.ld -C target-cpu=generic-rv32 -D warnings -D missing_docs" cargo rustc --target=riscv32imac-unknown-none-elf --features bsp_hifive1 --release
   Compiling kernel v0.1.0 (/home/kenkawamoto/personal/rust-raspberrypi-OS-tutorials/01_wait_forever)
    Finished release [optimized] target(s) in 0.19s
----------------
IN:
Priv: 3; Virt: 0
0x00001000:  204002b7          lui             t0,541065216
0x00001004:  00028067          jr              t0

----------------
IN:
Priv: 3; Virt: 0
0x20400000:  10500073          wfi
0x20400004:  bff5              j               -4              # 0x20400000
```

```
❯ make qemu BSP=hifive_unleashed
RUSTFLAGS="-C link-arg=-Tsrc/bsp/hifive_unleashed/link.ld -C target-cpu=generic-rv64 -D warnings -D missing_docs" cargo rustc --target=riscv64gc-unknown-none-elf --features bsp_hifive_unleashed --release
    Finished release [optimized] target(s) in 0.06s
----------------
IN:
Priv: 3; Virt: 0
0x0000000000001000:  00000297          auipc           t0,0            # 0x1000
0x0000000000001004:  02028593          addi            a1,t0,32
0x0000000000001008:  f1402573          csrrs           a0,mhartid,zero

----------------
IN:
Priv: 3; Virt: 0
0x0000000000001000:  00000297          auipc           t0,0            # 0x1000
0x0000000000001004:  02028593          addi            a1,t0,32
0x0000000000001008:  f1402573          csrrs           a0,mhartid,zero

----------------
IN:
Priv: 3; Virt: 0
0x000000000000100c:  0182b283          ld              t0,24(t0)
0x0000000000001010:  00028067          jr              t0

----------------
IN:
Priv: 3; Virt: 0
0x000000000000100c:  0182b283          ld              t0,24(t0)
0x0000000000001010:  00028067          jr              t0

----------------
IN:
Priv: 3; Virt: 0
0x0000000080000000:  10500073          wfi
0x0000000080000004:  bff5              j               -4              # 0x80000000

----------------
IN:
Priv: 3; Virt: 0
0x0000000080000000:  10500073          wfi
0x0000000080000004:  bff5              j               -4              # 0x80000000
```