### PR TITLE
Check chain load request token correctly

### DIFF
--- a/utils/minipush.rb
+++ b/utils/minipush.rb
@@ -31,12 +31,14 @@ class MiniPush < MiniTerm
         puts "[#{@name_short}] 🔌 Please power the target now"
 
         # Timeout for the request token starts after the first sign of life was received.
+        chars = []
         received = @target_serial.readpartial(4096)
         Timeout.timeout(10) do
             loop do
                 raise ProtocolError if received.nil?
 
-                if received.chars.last(3) == ["\u{3}", "\u{3}", "\u{3}"]
+                chars.concat(received.chars)
+                if chars.last(3) == ["\u{3}", "\u{3}", "\u{3}"]
                     # Print the last chunk minus the request token.
                     print received[0..-4]
                     return


### PR DESCRIPTION
Fix #98.

I found the minipush.rb have a bug.
When it is waiting for binary request, `received.chars.last(3)` returns incomplete request token like below. (The following logs are dump of `received.chars.last(3)`)

```
received '["u", "e"]'
received '["b", "i", "n"]'
received '["a", "r"]'
received '["\n", "\x03", "\x03"]'
received '["\x03"]'
```

Then, the request fails sometimes.

This patch fix the problem by buffering the request from binary.