### PR TITLE
update nightly version to make it work

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-04-25"
+channel = "nightly-2021-06-27"
 components = ["llvm-tools-preview"]
 targets = ["aarch64-unknown-none-softfloat"]


### PR DESCRIPTION
from "nightly-2021-04-25" to "nightly-2021-06-27"

### Description

<Please describe the issues fixed by this PR>
```
info: syncing channel updates for 'nightly-2021-04-25-x86_64-unknown-linux-gnu'
error: no release found for 'nightly-2021-04-25'
```
Related Issue: <https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/issues/113>


### Pre-commit steps

 - [ ] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [ ] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - This step is optional, but much appreciated if done.

        `./devtool ready_for_publish` fine. But `./contributor_setup.sh` ...
```bash
Bundle complete! 4 Gemfile dependencies, 13 gems now installed.
Bundled gems are installed into `./.vendor/bundle`
npm notice 
npm notice New minor version of npm available! 7.17.0 -> 7.19.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v7.19.0
npm notice Run npm install -g npm@7.19.0 to update!
npm notice 
npm ERR! code ECONNRESET
npm ERR! network aborted
npm ERR! network This is a problem related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network 
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/kearney/.npm/_logs/2021-06-29T15_18_10_602Z-debug.log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:01:30 --:--:--     0
```