### PR TITLE
chore(bcm): update pl011_uart RXFF register

### DIFF
--- a/05_drivers_gpio_uart/README.md
+++ b/05_drivers_gpio_uart/README.md
@@ -509,12 +509,12 @@ diff -uNr 04_safe_globals/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 05_dri
 +        /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
 +        TXFF OFFSET(5) NUMBITS(1) [],
 +
-+        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
++        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
 +        /// LCR_H Register.
-+        ///
-+        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-+        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-+
++        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
++        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
++        RXFF OFFSET(6) NUMBITS(1) [],
+
 +        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
 +        /// LCR_H Register.
 +        ///

--- a/05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/07_timestamps/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/07_timestamps/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/08_hw_debug_JTAG/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/08_hw_debug_JTAG/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/09_privilege_level/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/09_privilege_level/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/10_virtual_mem_part1_identity_mapping/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/10_virtual_mem_part1_identity_mapping/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/11_exceptions_part1_groundwork/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/11_exceptions_part1_groundwork/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/14_virtual_mem_part2_mmio_remap/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/14_virtual_mem_part2_mmio_remap/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,11 +50,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/15_virtual_mem_part3_precomputed_tables/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/15_virtual_mem_part3_precomputed_tables/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,11 +50,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/16_virtual_mem_part4_higher_half_kernel/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/16_virtual_mem_part4_higher_half_kernel/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,11 +50,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.

--- a/X1_JTAG_boot/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/X1_JTAG_boot/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -47,11 +47,11 @@ register_bitfields! {
         /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
         TXFF OFFSET(5) NUMBITS(1) [],
 
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
+        /// Receive FIFO full. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
-        ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
+        /// - If the FIFO is disabled, this bit is set when the receive holding register is full.
+        /// - If the FIFO is enabled, the RXFF bit is set when the receive FIFO is full.
+        RXFF OFFSET(6) NUMBITS(1) [],
 
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.


### PR DESCRIPTION
### Description

The comments on [05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs) misses the `RXFF` register. Though this doesn't affect compile the kernel, but I think PR made it more clear.

Related Issue: <Insert link here if applicable>

### Pre-commit steps

 - [x] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [ ] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - This step is optional, but much appreciated if done.
