### PR TITLE
docs: Remove pl011_uart duplicate comments.

### DIFF
--- a/05_drivers_gpio_uart/README.md
+++ b/05_drivers_gpio_uart/README.md
@@ -459,7 +459,7 @@ diff -uNr 04_safe_globals/src/bsp/device_driver/bcm/bcm2xxx_gpio.rs 05_drivers_g
 diff -uNr 04_safe_globals/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
 --- 04_safe_globals/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
 +++ 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
-@@ -0,0 +1,408 @@
+@@ -0,0 +1,402 @@
 +// SPDX-License-Identifier: MIT OR Apache-2.0
 +//
 +// Copyright (c) 2018-2021 Andre Richter <andre.o.richter@gmail.com>
@@ -508,12 +508,6 @@ diff -uNr 04_safe_globals/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 05_dri
 +        /// - If the FIFO is disabled, this bit is set when the transmit holding register is full.
 +        /// - If the FIFO is enabled, the TXFF bit is set when the transmit FIFO is full.
 +        TXFF OFFSET(5) NUMBITS(1) [],
-+
-+        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-+        /// LCR_H Register.
-+        ///
-+        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-+        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
 +
 +        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
 +        /// LCR_H Register.

--- a/05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/06_uart_chainloader/README.md
+++ b/06_uart_chainloader/README.md
@@ -339,7 +339,7 @@ diff -uNr 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_gpio.rs 06_uart
 diff -uNr 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
 --- 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
 +++ 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
-@@ -284,7 +284,7 @@
+@@ -278,7 +278,7 @@
      }
 
      /// Retrieve a character.
@@ -348,7 +348,7 @@ diff -uNr 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 0
          // If RX FIFO is empty,
          if self.registers.FR.matches_all(FR::RXFE::SET) {
              // immediately return in non-blocking mode.
-@@ -299,12 +299,7 @@
+@@ -293,12 +293,7 @@
          }
 
          // Read one character.
@@ -362,7 +362,7 @@ diff -uNr 05_drivers_gpio_uart/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 0
 
          // Update statistics.
          self.chars_read += 1;
-@@ -384,14 +379,14 @@
+@@ -378,14 +373,14 @@
  impl console::interface::Read for PL011Uart {
      fn read_char(&self) -> char {
          self.inner

--- a/06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/07_timestamps/README.md
+++ b/07_timestamps/README.md
@@ -408,7 +408,7 @@ diff -uNr 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_gpio.rs 07_times
 diff -uNr 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 07_timestamps/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
 --- 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
 +++ 07_timestamps/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
-@@ -284,7 +284,7 @@
+@@ -278,7 +278,7 @@
      }
 
      /// Retrieve a character.
@@ -417,7 +417,7 @@ diff -uNr 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 07
          // If RX FIFO is empty,
          if self.registers.FR.matches_all(FR::RXFE::SET) {
              // immediately return in non-blocking mode.
-@@ -299,7 +299,12 @@
+@@ -293,7 +293,12 @@
          }
 
          // Read one character.
@@ -431,7 +431,7 @@ diff -uNr 06_uart_chainloader/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 07
 
          // Update statistics.
          self.chars_read += 1;
-@@ -379,14 +384,14 @@
+@@ -373,14 +378,14 @@
  impl console::interface::Read for PL011Uart {
      fn read_char(&self) -> char {
          self.inner

--- a/07_timestamps/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/07_timestamps/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/08_hw_debug_JTAG/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/08_hw_debug_JTAG/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/09_privilege_level/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/09_privilege_level/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/10_virtual_mem_part1_identity_mapping/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/10_virtual_mem_part1_identity_mapping/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/11_exceptions_part1_groundwork/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/11_exceptions_part1_groundwork/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/13_exceptions_part2_peripheral_IRQs/README.md
+++ b/13_exceptions_part2_peripheral_IRQs/README.md
@@ -1867,7 +1867,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
  };
  use core::fmt;
  use tock_registers::{
-@@ -140,6 +140,52 @@
+@@ -134,6 +134,52 @@
          ]
      ],
 
@@ -1920,7 +1920,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
      /// Interrupt Clear Register.
      ICR [
          /// Meta field for all pending interrupts.
-@@ -158,7 +204,10 @@
+@@ -152,7 +198,10 @@
          (0x28 => FBRD: WriteOnly<u32, FBRD::Register>),
          (0x2c => LCR_H: WriteOnly<u32, LCR_H::Register>),
          (0x30 => CR: WriteOnly<u32, CR::Register>),
@@ -1932,7 +1932,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
          (0x44 => ICR: WriteOnly<u32, ICR::Register>),
          (0x48 => @END),
      }
-@@ -188,7 +237,8 @@
+@@ -182,7 +231,8 @@
 
  /// Representation of the UART.
  pub struct PL011Uart {
@@ -1942,7 +1942,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
  }
 
  //--------------------------------------------------------------------------------------------------
-@@ -256,6 +306,14 @@
+@@ -250,6 +300,14 @@
              .LCR_H
              .write(LCR_H::WLEN::EightBit + LCR_H::FEN::FifosEnabled);
 
@@ -1957,7 +1957,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
          // Turn the UART on.
          self.registers
              .CR
-@@ -338,9 +396,13 @@
+@@ -332,9 +390,13 @@
      /// # Safety
      ///
      /// - The user must ensure to provide a correct MMIO start address.
@@ -1973,7 +1973,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
          }
      }
  }
-@@ -360,6 +422,21 @@
+@@ -354,6 +416,21 @@
 
          Ok(())
      }
@@ -1995,7 +1995,7 @@ diff -uNr 12_integrated_testing/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs 
  }
 
  impl console::interface::Write for PL011Uart {
-@@ -406,3 +483,24 @@
+@@ -400,3 +477,24 @@
          self.inner.lock(|inner| inner.chars_read)
      }
  }

--- a/13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/14_virtual_mem_part2_mmio_remap/README.md
+++ b/14_virtual_mem_part2_mmio_remap/README.md
@@ -1266,7 +1266,7 @@ diff -uNr 13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_
  use tock_registers::{
      interfaces::{Readable, Writeable},
      register_bitfields, register_structs,
-@@ -237,6 +240,8 @@
+@@ -231,6 +234,8 @@
 
  /// Representation of the UART.
  pub struct PL011Uart {
@@ -1275,7 +1275,7 @@ diff -uNr 13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_
      inner: IRQSafeNullLock<PL011UartInner>,
      irq_number: bsp::device_driver::IRQNumber,
  }
-@@ -276,7 +281,15 @@
+@@ -270,7 +275,15 @@
      /// genrated baud rate of `48_000_000 / (16 * 3.25) = 923_077`.
      ///
      /// Error = `((923_077 - 921_600) / 921_600) * 100 = 0.16modulo`.
@@ -1292,7 +1292,7 @@ diff -uNr 13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_
          // Execution can arrive here while there are still characters queued in the TX FIFO and
          // actively being sent out by the UART hardware. If the UART is turned off in this case,
          // those queued characters would be lost.
-@@ -318,6 +331,8 @@
+@@ -312,6 +325,8 @@
          self.registers
              .CR
              .write(CR::UARTEN::Enabled + CR::TXE::Enabled + CR::RXE::Enabled);
@@ -1301,7 +1301,7 @@ diff -uNr 13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_
      }
 
      /// Send a character.
-@@ -395,13 +410,18 @@
+@@ -389,13 +404,18 @@
      ///
      /// # Safety
      ///
@@ -1323,7 +1323,7 @@ diff -uNr 13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_
              irq_number,
          }
      }
-@@ -418,7 +438,13 @@
+@@ -412,7 +432,13 @@
      }
 
      unsafe fn init(&self) -> Result<(), &'static str> {
@@ -1338,7 +1338,7 @@ diff -uNr 13_exceptions_part2_peripheral_IRQs/src/bsp/device_driver/bcm/bcm2xxx_
 
          Ok(())
      }
-@@ -437,6 +463,16 @@
+@@ -431,6 +457,16 @@
 
          Ok(())
      }

--- a/14_virtual_mem_part2_mmio_remap/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/14_virtual_mem_part2_mmio_remap/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -53,12 +53,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/15_virtual_mem_part3_precomputed_tables/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/15_virtual_mem_part3_precomputed_tables/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -53,12 +53,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/16_virtual_mem_part4_higher_half_kernel/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/16_virtual_mem_part4_higher_half_kernel/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -53,12 +53,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],

--- a/X1_JTAG_boot/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
+++ b/X1_JTAG_boot/src/bsp/device_driver/bcm/bcm2xxx_pl011_uart.rs
@@ -50,12 +50,6 @@ register_bitfields! {
         /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
         /// LCR_H Register.
         ///
-        /// If the FIFO is disabled, this bit is set when the receive holding register is empty. If
-        /// the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
-
-        /// Receive FIFO empty. The meaning of this bit depends on the state of the FEN bit in the
-        /// LCR_H Register.
-        ///
         /// - If the FIFO is disabled, this bit is set when the receive holding register is empty.
         /// - If the FIFO is enabled, the RXFE bit is set when the receive FIFO is empty.
         RXFE OFFSET(4) NUMBITS(1) [],


### PR DESCRIPTION
### Description

Remove pl011_uart duplicate comments.

### Pre-commit steps

 - [x] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [x] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - This step is optional, but much appreciated if done.
