### PR TITLE
Fix a typo

### DIFF
--- a/04_safe_globals/README.md
+++ b/04_safe_globals/README.md
@@ -177,7 +177,7 @@ diff -uNr 03_hacky_hello_world/src/bsp/raspberrypi/console.rs 04_safe_globals/sr
 +/// serialize access.
 +impl console::interface::Write for QEMUOutput {
 +    fn write_fmt(&self, args: core::fmt::Arguments) -> fmt::Result {
-+        // Fully qualified syntax for the call to `core::fmt::Write::write:fmt()` to increase
++        // Fully qualified syntax for the call to `core::fmt::Write::write_fmt()` to increase
 +        // readability.
 +        self.inner.lock(|inner| fmt::Write::write_fmt(inner, args))
 +    }


### PR DESCRIPTION
### Description

Just fixing a typo

Related Issue: <Insert link here if applicable>

### Pre-commit steps

 - [ ] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [x] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - This step is optional, but much appreciated if done.
