### PR TITLE
chore: replace `git.io` link with the original URL

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -34,7 +34,7 @@ jobs:
           npm install prettier
       - name: Setup misspell
         run: |
-          curl -L -o ./install-misspell.sh https://git.io/misspell
+          curl -L -o ./install-misspell.sh https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh
           sh ./install-misspell.sh -b .vendor
       - name: Run checks
         run: |

--- a/01_wait_forever/src/main.rs
+++ b/01_wait_forever/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/02_runtime_init/src/main.rs
+++ b/02_runtime_init/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/03_hacky_hello_world/src/main.rs
+++ b/03_hacky_hello_world/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/04_safe_globals/src/main.rs
+++ b/04_safe_globals/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/05_drivers_gpio_uart/src/main.rs
+++ b/05_drivers_gpio_uart/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/06_uart_chainloader/src/main.rs
+++ b/06_uart_chainloader/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/07_timestamps/src/main.rs
+++ b/07_timestamps/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/08_hw_debug_JTAG/src/main.rs
+++ b/08_hw_debug_JTAG/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/09_privilege_level/src/main.rs
+++ b/09_privilege_level/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/10_virtual_mem_part1_identity_mapping/src/main.rs
+++ b/10_virtual_mem_part1_identity_mapping/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/11_exceptions_part1_groundwork/src/main.rs
+++ b/11_exceptions_part1_groundwork/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/12_integrated_testing/kernel/src/lib.rs
+++ b/12_integrated_testing/kernel/src/lib.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` library.
 //!

--- a/12_integrated_testing/kernel/src/main.rs
+++ b/12_integrated_testing/kernel/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 

--- a/13_exceptions_part2_peripheral_IRQs/kernel/src/lib.rs
+++ b/13_exceptions_part2_peripheral_IRQs/kernel/src/lib.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` library.
 //!

--- a/13_exceptions_part2_peripheral_IRQs/kernel/src/main.rs
+++ b/13_exceptions_part2_peripheral_IRQs/kernel/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 

--- a/14_virtual_mem_part2_mmio_remap/kernel/src/lib.rs
+++ b/14_virtual_mem_part2_mmio_remap/kernel/src/lib.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` library.
 //!

--- a/14_virtual_mem_part2_mmio_remap/kernel/src/main.rs
+++ b/14_virtual_mem_part2_mmio_remap/kernel/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 

--- a/15_virtual_mem_part3_precomputed_tables/kernel/src/lib.rs
+++ b/15_virtual_mem_part3_precomputed_tables/kernel/src/lib.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` library.
 //!

--- a/15_virtual_mem_part3_precomputed_tables/kernel/src/main.rs
+++ b/15_virtual_mem_part3_precomputed_tables/kernel/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 

--- a/16_virtual_mem_part4_higher_half_kernel/kernel/src/lib.rs
+++ b/16_virtual_mem_part4_higher_half_kernel/kernel/src/lib.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` library.
 //!

--- a/16_virtual_mem_part4_higher_half_kernel/kernel/src/main.rs
+++ b/16_virtual_mem_part4_higher_half_kernel/kernel/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 

--- a/17_kernel_symbols/kernel/src/lib.rs
+++ b/17_kernel_symbols/kernel/src/lib.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` library.
 //!

--- a/17_kernel_symbols/kernel/src/main.rs
+++ b/17_kernel_symbols/kernel/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 

--- a/X1_JTAG_boot/src/main.rs
+++ b/X1_JTAG_boot/src/main.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
 
 // Rust embedded logo for `make doc`.
-#![doc(html_logo_url = "https://git.io/JeGIp")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/rust-embedded/wg/master/assets/logo/ewg-logo-blue-white-on-transparent.png")]
 
 //! The `kernel` binary.
 //!

--- a/contributor_setup.sh
+++ b/contributor_setup.sh
@@ -31,6 +31,6 @@ then
     echo "'curl' could not be found. Please install it."
     exit
 fi
-curl -L -o ./install-misspell.sh https://git.io/misspell
+curl -L -o ./install-misspell.sh https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh
 sh ./install-misspell.sh -b .vendor
 rm install-misspell.sh


### PR DESCRIPTION
### Description

[Git.io deprecation](https://github.blog/changelog/2022-04-25-git-io-deprecation/)
Update any existing links that make use `git.io` URL services
<Please describe the issues fixed by this PR>

Related Issue: n/a

### Pre-commit steps

 - [ ] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [x] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - This step is optional, but much appreciated if done.
