### PR TITLE
Add VSCode Rust Analyzer Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
   "editor.formatOnSave": true,
-  "editor.rulers": [100]
+  "editor.rulers": [100],
+  "rust-analyzer.cargo.target": "aarch64-unknown-none-softfloat",
+  "rust-analyzer.cargo.features": ["bsp_rpi3"],
+  "rust-analyzer.checkOnSave.allTargets": false,
+  "rust-analyzer.checkOnSave.extraArgs": ["--lib", "--bins"],
+  "rust-analyzer.lens.debug": false,
+  "rust-analyzer.lens.run": false
 }


### PR DESCRIPTION


### Description

Fixes errors reported by rust analyzer due to differing target and a missing cargo feature.

I'm not sure if I'm the only one who ran into this or not, so feel free to close if this shouldn't be needed for some reason!

### Pre-commit steps

 - [ ] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [x] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - If no Rust-related files were changed, `./devtool ready_for_publish_no_rust` can be used instead (faster).
     - This step is optional, but much appreciated if done.

> **Note:** I ran the second step above, and it generated a bunch of changes in the "diff to previous" sections, but the only change was to add a timestamp to all the diffs, which I'm assuming is just a different version of diff on my system, and is tangential to the change this PR makes, so I just didn't commit those files. 
