### PR TITLE
Fix CI/CD check error

### DIFF
--- a/01_wait_forever/Makefile
+++ b/01_wait_forever/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/02_runtime_init/Makefile
+++ b/02_runtime_init/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/03_hacky_hello_world/Makefile
+++ b/03_hacky_hello_world/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/04_safe_globals/Makefile
+++ b/04_safe_globals/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/05_drivers_gpio_uart/Makefile
+++ b/05_drivers_gpio_uart/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/06_uart_chainloader/Makefile
+++ b/06_uart_chainloader/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/07_timestamps/Makefile
+++ b/07_timestamps/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/08_hw_debug_JTAG/Makefile
+++ b/08_hw_debug_JTAG/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/09_privilege_level/Makefile
+++ b/09_privilege_level/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/10_virtual_mem_part1_identity_mapping/Makefile
+++ b/10_virtual_mem_part1_identity_mapping/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/11_exceptions_part1_groundwork/Makefile
+++ b/11_exceptions_part1_groundwork/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/12_integrated_testing/Makefile
+++ b/12_integrated_testing/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/13_exceptions_part2_peripheral_IRQs/Makefile
+++ b/13_exceptions_part2_peripheral_IRQs/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/14_virtual_mem_part2_mmio_remap/Makefile
+++ b/14_virtual_mem_part2_mmio_remap/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/15_virtual_mem_part3_precomputed_tables/Makefile
+++ b/15_virtual_mem_part3_precomputed_tables/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/16_virtual_mem_part4_higher_half_kernel/Makefile
+++ b/16_virtual_mem_part4_higher_half_kernel/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/17_kernel_symbols/Makefile
+++ b/17_kernel_symbols/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/17_kernel_symbols/kernel_symbols.mk
+++ b/17_kernel_symbols/kernel_symbols.mk
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/format.mk
 include ../common/docker.mk

--- a/18_backtrace/Makefile
+++ b/18_backtrace/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/18_backtrace/kernel_symbols.mk
+++ b/18_backtrace/kernel_symbols.mk
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/format.mk
 include ../common/docker.mk

--- a/19_kernel_heap/Makefile
+++ b/19_kernel_heap/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/19_kernel_heap/kernel_symbols.mk
+++ b/19_kernel_heap/kernel_symbols.mk
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/format.mk
 include ../common/docker.mk

--- a/20_timer_callbacks/Makefile
+++ b/20_timer_callbacks/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk

--- a/20_timer_callbacks/kernel_symbols.mk
+++ b/20_timer_callbacks/kernel_symbols.mk
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/format.mk
 include ../common/docker.mk

--- a/X1_JTAG_boot/Makefile
+++ b/X1_JTAG_boot/Makefile
@@ -1,6 +1,6 @@
 ## SPDX-License-Identifier: MIT OR Apache-2.0
 ##
-## Copyright (c) 2018-2022 Andre Richter <andre.o.richter@gmail.com>
+## Copyright (c) 2018-2023 Andre Richter <andre.o.richter@gmail.com>
 
 include ../common/docker.mk
 include ../common/format.mk


### PR DESCRIPTION
### Description

<Please describe the issues fixed by this PR>

Related Issue: CC #184，I think it's possible to modify the Github CI/CD program, as the problem should arise here. However, I believe that changing the correct year is the best choice because there are issues with year copyright itself

### Pre-commit steps

 - [x] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [x] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - If no Rust-related files were changed, `./devtool ready_for_publish_no_rust` can be used instead (faster).
     - This step is optional, but much appreciated if done.
