### PR TITLE
Add initial Rpi4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/target/*
 **/.gdb_history
 **/kernel8.img
+**/.idea
 
 node_modules
 .bundle

--- a/01_wait_forever/Makefile
+++ b/01_wait_forever/Makefile
@@ -35,7 +35,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -d in_asm -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/02_runtime_init/Makefile
+++ b/02_runtime_init/Makefile
@@ -35,7 +35,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -d in_asm -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/03_hacky_hello_world/Makefile
+++ b/03_hacky_hello_world/Makefile
@@ -35,7 +35,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/03_hacky_hello_world/README.md
+++ b/03_hacky_hello_world/README.md
@@ -65,7 +65,7 @@ diff -uNr 02_runtime_init/Makefile 03_hacky_hello_world/Makefile
 @@ -36,7 +36,7 @@
      KERNEL_BIN        = kernel8.img
      QEMU_BINARY       = qemu-system-aarch64
-     QEMU_MACHINE_TYPE =
+     QEMU_MACHINE_TYPE = raspi4
 -    QEMU_RELEASE_ARGS = -d in_asm -display none
 +    QEMU_RELEASE_ARGS = -serial stdio -display none
      OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/03_hacky_hello_world/src/panic_wait.rs
+++ b/03_hacky_hello_world/src/panic_wait.rs
@@ -51,13 +51,14 @@ fn panic(info: &PanicInfo) -> ! {
     };
 
     println!(
-        "Kernel panic!\n\n\
-        Panic location:\n      File '{}', line {}, column {}\n\n\
-        {}",
+        "Kernel panic!\n\
+         {space}Panic message:\n{space}{space}{}\n\
+         {space}Panic location:\n{space}{space}File '{}', line {}, column {}",
+        info.message().unwrap_or(&format_args!("")),
         location,
         line,
         column,
-        info.message().unwrap_or(&format_args!("")),
+        space = "    ",
     );
 
     cpu::wait_forever()

--- a/04_safe_globals/Makefile
+++ b/04_safe_globals/Makefile
@@ -35,7 +35,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/05_drivers_gpio_uart/Makefile
+++ b/05_drivers_gpio_uart/Makefile
@@ -38,7 +38,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/07_timestamps/Makefile
+++ b/07_timestamps/Makefile
@@ -38,7 +38,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/08_hw_debug_JTAG/Makefile
+++ b/08_hw_debug_JTAG/Makefile
@@ -40,7 +40,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/09_privilege_level/Makefile
+++ b/09_privilege_level/Makefile
@@ -40,7 +40,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/10_virtual_mem_part1_identity_mapping/Makefile
+++ b/10_virtual_mem_part1_identity_mapping/Makefile
@@ -40,7 +40,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/11_exceptions_part1_groundwork/Makefile
+++ b/11_exceptions_part1_groundwork/Makefile
@@ -40,7 +40,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/12_integrated_testing/Makefile
+++ b/12_integrated_testing/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/12_integrated_testing/README.md
+++ b/12_integrated_testing/README.md
@@ -449,7 +449,7 @@ provided to it by `cargo`, and finally compiles a `docker` command to execute th
 reference, here it is fully resolved for an `RPi3 BSP`:
 
 ```bash
-docker run -t --rm -v /opt/rust-raspberrypi-OS-tutorials/12_integrated_testing:/work/tutorial -w /work/tutorial -v /opt/rust-raspberrypi-OS-tutorials/12_integrated_testing/../common:/work/common rustembedded/osdev-utils:2021.12 ruby ../common/tests/dispatch.rb qemu-system-aarch64 -M raspi3 -serial stdio -display none -semihosting -kernel $TEST_BINARY
+docker run -t --rm -v /opt/rust-raspberrypi-OS-tutorials/12_integrated_testing:/work/tutorial -w /work/tutorial -v /opt/rust-raspberrypi-OS-tutorials/12_integrated_testing/../common:/work/common u007d/osdev-utils-rpi4:2023.09 ruby ../common/tests/dispatch.rb qemu-system-aarch64 -M raspi3 -serial stdio -display none -semihosting -kernel $TEST_BINARY
 ```
 
 This command is quite similar to the one used in the `make test_boot` target that we have since

--- a/13_exceptions_part2_peripheral_IRQs/Makefile
+++ b/13_exceptions_part2_peripheral_IRQs/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/14_virtual_mem_part2_mmio_remap/Makefile
+++ b/14_virtual_mem_part2_mmio_remap/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/15_virtual_mem_part3_precomputed_tables/Makefile
+++ b/15_virtual_mem_part3_precomputed_tables/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/16_virtual_mem_part4_higher_half_kernel/Makefile
+++ b/16_virtual_mem_part4_higher_half_kernel/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/17_kernel_symbols/Makefile
+++ b/17_kernel_symbols/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/18_backtrace/Makefile
+++ b/18_backtrace/Makefile
@@ -48,7 +48,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/19_kernel_heap/Makefile
+++ b/19_kernel_heap/Makefile
@@ -53,7 +53,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/20_timer_callbacks/Makefile
+++ b/20_timer_callbacks/Makefile
@@ -53,7 +53,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     QEMU_TEST_ARGS    = $(QEMU_RELEASE_ARGS) -semihosting
     OBJDUMP_BINARY    = aarch64-none-elf-objdump

--- a/X1_JTAG_boot/Makefile
+++ b/X1_JTAG_boot/Makefile
@@ -38,7 +38,7 @@ else ifeq ($(BSP),rpi4)
     TARGET            = aarch64-unknown-none-softfloat
     KERNEL_BIN        = kernel8.img
     QEMU_BINARY       = qemu-system-aarch64
-    QEMU_MACHINE_TYPE =
+    QEMU_MACHINE_TYPE = raspi4
     QEMU_RELEASE_ARGS = -serial stdio -display none
     OBJDUMP_BINARY    = aarch64-none-elf-objdump
     NM_BINARY         = aarch64-none-elf-nm

--- a/common/docker.mk
+++ b/common/docker.mk
@@ -1,1 +1,1 @@
-DOCKER_IMAGE := rustembedded/osdev-utils:2021.12
+DOCKER_IMAGE := u007d/osdev-utils-rpi4:2023.09

--- a/docker/rustembedded-osdev-utils/Makefile
+++ b/docker/rustembedded-osdev-utils/Makefile
@@ -4,14 +4,14 @@
 
 # Reference followed: https://www.docker.com/blog/getting-started-with-docker-for-arm-on-linux
 
-TAG := 2021.12
+TAG := 2023.09
 
 default: build_local
 
 build_local:
 	cp ../../Gemfile .
 	docker build                                           \
-	    --tag rustembedded/osdev-utils:$(TAG)              \
+	    --tag u007d/osdev-utils-rpi4:$(TAG)              \
 	    --build-arg VCS_REF=`git rev-parse --short HEAD` .
 	rm Gemfile
 
@@ -20,6 +20,6 @@ buildx_push:
 	docker buildx build                                    \
 	    --push                                             \
 	    --platform linux/arm64/v8,linux/amd64              \
-	    --tag rustembedded/osdev-utils:$(TAG)              \
+	    --tag u007d/osdev-utils-rpi4:$(TAG)              \
 	    --build-arg VCS_REF=`git rev-parse --short HEAD` .
 	rm Gemfile


### PR DESCRIPTION
### Description

* I built a patched version of QEMU with RPi4 support (see https://github.com/U007D/qemu-raspi4)
* Updated the Docker image to use this build (see https://hub.docker.com/repository/docker/u007d/osdev-utils-rpi4/general)
* Updated references in this repo to use updated Docker image (feel free to clone/update your Docker image and switch the references back to your image).

### Pre-commit steps

 - [x] Tested on QEMU and real HW Rasperry Pi.
     - rpi4 did not pass `03_hacky_hello_world` on QEMU.  This may or may not be expected given the state of the QEMU patch, or given the differences in `rpi3` and `rpi4`, but I thought I would share the work in case this was an issue you were familiar with.
 - [ ] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - If no Rust-related files were changed, `./devtool ready_for_publish_no_rust` can be used instead (faster).
     - This step is optional, but much appreciated if done.
