### PR TITLE
fix depracated link to the rust-toolchain.toml file

### DIFF
--- a/README.ES.md
+++ b/README.ES.md
@@ -64,7 +64,7 @@ Muchas de las cosas vistas aquí también funcionan en **macOS**, pero esto solo
 
 2. (**Solo para Linux**) Asegúrate de que la cuenta de tu usuario está en el [grupo `docker`][docker group].
 
-3. Prepara la `Rust` toolchain. La mayor parte se hará automáticamente durante el primer uso del archivo [rust-toolchain](rust-toolchain). 
+3. Prepara la `Rust` toolchain. La mayor parte se hará automáticamente durante el primer uso del archivo [rust-toolchain.toml](rust-toolchain.toml). 
    Todo lo que nos queda hacer a nosotros es: 
    
    i. Si ya tienes una versión de Rust instalada:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The tutorials are primarily targeted at **Linux**-based distributions. Most stuf
 1. [Install Docker Engine][install_docker].
 1. (**Linux only**) Ensure your user account is in the [docker group].
 1. Prepare the `Rust` toolchain. Most of it will be handled on first use through the
-   [rust-toolchain](rust-toolchain) file. What's left for us to do is:
+   [rust-toolchain.toml](rust-toolchain.toml) file. What's left for us to do is:
    1. If you already have a version of Rust installed:
       ```bash
       cargo install cargo-binutils rustfilt


### PR DESCRIPTION
### Description

The link provided in the [🚀 Version tl;dr](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/README.md#-the-tldr-version) section System Requirements in README.md seems was deprecated. The issue concerns also the `README.ES.md`.

Related Issue:  https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/issues/197
     
### Pre-commit steps - response:
This is just a README change, only `./devtool ready_for_publish_no_rust` was run.

Fixes #197
