### PR TITLE
Remove `asm_const` attribute because it is no longer required

### DIFF
--- a/02_runtime_init/src/main.rs
+++ b/02_runtime_init/src/main.rs
@@ -106,7 +106,6 @@
 //!     - It is implemented in `src/_arch/__arch_name__/cpu/boot.s`.
 //! 2. Once finished with architectural setup, the arch code calls `kernel_init()`.
 
-#![feature(asm_const)]
 #![no_main]
 #![no_std]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-10-13"
+channel = "nightly-2024-10-15"
 components = ["rust-src", "llvm-tools-preview", "rustfmt"]
 targets = ["aarch64-unknown-none-softfloat"]


### PR DESCRIPTION
### Description
I got this error:
```
error: the feature `asm_const` has been stable since 1.82.0 and no longer requires an attribute to enable
   --> src/main.rs:109:12
    |
109 | #![feature(asm_const)]
    |            ^^^^^^^^^
    |
    = note: `-D stable-features` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(stable_features)]`
```
so I removed the line and created this PR. I tested it in QEMU and it worked. Real HW raspberry Pi is not applicable since it's just tutorial 2.


<Please describe the issues fixed by this PR>

### Pre-commit steps

 - [ ] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [ ] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - If no Rust-related files were changed, `./devtool ready_for_publish_no_rust` can be used instead (faster).
     - This step is optional, but much appreciated if done.
